### PR TITLE
Make visualization viewer configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
 )
+add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_generate_message_cpp ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS})
 
 # Declare C++ executables
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ generate_messages(
 
 catkin_package(
   CATKIN_DEPENDS 
-  message_generation
+  message_runtime
   cv_bridge
   INCLUDE_DIRS
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,6 @@ include_directories(
 )
 
 add_message_files(
-  DIRECTORY msg
   FILES
   Subsections.msg
 )
@@ -52,6 +51,7 @@ add_message_files(
 generate_messages(
    DEPENDENCIES
    geometry_msgs
+   std_msgs
 )
 
 catkin_package(

--- a/config/plane_detection_paramenters.yaml
+++ b/config/plane_detection_paramenters.yaml
@@ -15,6 +15,6 @@ plane_segment:
 
 pointcloud:
   base_frame: "map"
-  topic_name: "/oil/perception/head_camera/filtered_cloud"
+  topic_name: "/oil/perception/head_camera/cloud"
 
 viz: false

--- a/config/plane_detection_paramenters.yaml
+++ b/config/plane_detection_paramenters.yaml
@@ -16,3 +16,5 @@ plane_segment:
 pointcloud:
   base_frame: "map"
   topic_name: "/oil/perception/head_camera/filtered_cloud"
+
+viz: false

--- a/src/hope_node.cpp
+++ b/src/hope_node.cpp
@@ -73,7 +73,7 @@ void phaseInput(string input, vector<string> &vrgb, vector<string> &vdepth,
   ifstream list(input.c_str());
   
   if(!list){
-    cout << "Unable to open the list" << endl;
+    ROS_ERROR("Unable to open the list");
     return;
   }
   char rgb[27];

--- a/src/hope_ros.cpp
+++ b/src/hope_ros.cpp
@@ -89,6 +89,7 @@ int main(int argc, char **argv)
   pnh.getParam("/hope_ros/plane_segment/z_resolution", params.z_resolution);
   pnh.getParam("/hope_ros/pointcloud/base_frame", params.base_frame);
   pnh.getParam("/hope_ros/pointcloud/topic_name", params.cloud_topic);
+  pnh.getParam("/hope_ros/viz", params.viz);
 
   PlaneSegment hope(params, nh);
 

--- a/src/hope_ros.cpp
+++ b/src/hope_ros.cpp
@@ -79,17 +79,17 @@ int main(int argc, char **argv)
 
   Params params;
 
-  pnh.getParam("/hope_ros/blob_properties/x_dimension", params.x_dim);
-  pnh.getParam("/hope_ros/blob_properties/y_dimension", params.y_dim);
-  pnh.getParam("/hope_ros/ground_clearance/min_height", params.z_min);
-  pnh.getParam("/hope_ros/ground_clearance/max_height", params.z_max);
-  pnh.getParam("/hope_ros/blob_properties/min_surface_area", params.area_min);
-  pnh.getParam("/hope_ros/blob_properties/max_surface_area", params.area_max);
-  pnh.getParam("/hope_ros/plane_segment/xy_resolution", params.xy_resolution);
-  pnh.getParam("/hope_ros/plane_segment/z_resolution", params.z_resolution);
-  pnh.getParam("/hope_ros/pointcloud/base_frame", params.base_frame);
-  pnh.getParam("/hope_ros/pointcloud/topic_name", params.cloud_topic);
-  pnh.getParam("/hope_ros/viz", params.viz);
+  pnh.getParam("blob_properties/x_dimension", params.x_dim);
+  pnh.getParam("blob_properties/y_dimension", params.y_dim);
+  pnh.getParam("ground_clearance/min_height", params.z_min);
+  pnh.getParam("ground_clearance/max_height", params.z_max);
+  pnh.getParam("blob_properties/min_surface_area", params.area_min);
+  pnh.getParam("blob_properties/max_surface_area", params.area_max);
+  pnh.getParam("plane_segment/xy_resolution", params.xy_resolution);
+  pnh.getParam("plane_segment/z_resolution", params.z_resolution);
+  pnh.getParam("pointcloud/base_frame", params.base_frame);
+  pnh.getParam("pointcloud/topic_name", params.cloud_topic);
+  pnh.getParam("viz", params.viz);
 
   PlaneSegment hope(params, nh);
 

--- a/src/hope_ros.cpp
+++ b/src/hope_ros.cpp
@@ -67,15 +67,14 @@ int main(int argc, char **argv)
   data_type type;
 
   type = REAL;
-  ROS_INFO("Using real data.");
+  ROS_DEBUG("Using real data.");
 
   ros::NodeHandle nh;
   ros::NodeHandle pnh("~");
 
   float xy_resolution, z_resolution; // In meter
 
-  cout << "Using threshold: xy@" << xy_resolution 
-       << " " << "z@" << z_resolution << endl;
+  ROS_DEBUG_STREAM("Using threshold: xy@" << xy_resolution << " " << "z@" << z_resolution);
 
   Params params;
 

--- a/src/lib/plane_segment.cpp
+++ b/src/lib/plane_segment.cpp
@@ -140,7 +140,7 @@ void PlaneSegment::getHorizontalPlanes()
     src_sp_rgb_ = src_rgb_cloud_;
   }
   //visualizeProcess(src_sp_rgb_);
-  cout << "Point number after down sampling: #" << src_sp_rgb_->points.size() << endl;
+  ROS_DEBUG_STREAM("Point number after down sampling: #" << src_sp_rgb_->points.size());
 
   if (src_sp_mono_->points.empty()) {
     ROS_WARN("PlaneSegment: Source cloud is empty.");
@@ -165,8 +165,8 @@ void PlaneSegment::getHorizontalPlanes()
   //findAllPlanesRG(20, 20, 8.0, 1.0);
   
   // Stop timer and get total processing time
-  hst_.stop();
-  hst_.print();
+  // hst_.stop();
+  // hst_.print();
 
   setID();
   if(viz){
@@ -306,7 +306,7 @@ void PlaneSegment::computeHull(PointCloud::Ptr cluster_2d_rgb)
 
 void PlaneSegment::setFeatures(float z_in, PointCloudMono::Ptr cluster)
 {
-  ROS_INFO("Polygon found");
+  ROS_DEBUG("Polygon found");
   // Prepare the feature vector for each plane to identify its id
   vector<float> feature;
   feature.push_back(z_in); // z value
@@ -320,11 +320,11 @@ void PlaneSegment::setFeatures(float z_in, PointCloudMono::Ptr cluster)
   geometry_msgs::Polygon polygon_points;
   double area = (maxPt.y - minPt.y) * (maxPt.x - minPt.x);
   if (z_in < z_min_ || z_in > z_max_) {
-    ROS_INFO("Plane ignored because of not within required height range");
+    ROS_DEBUG("Plane ignored because of not within required height range");
     return;
   }
   else if (area < min_area_ || area > max_area_) {
-  	ROS_INFO("Plane ignored because of not within required area range");
+  	ROS_DEBUG("Plane ignored because of not within required area range");
     return;
   }
   subsections_.subsection_array.clear();
@@ -696,7 +696,7 @@ void PlaneSegment::visualizeResult(bool display_source, bool display_raw,
     }
   }
 
-  cout << "Total plane patches #: " << plane_points_.size() << endl;
+  ROS_DEBUG_STREAM("Total plane patches #: " << plane_points_.size());
 
   while (!viewer->wasStopped()) {
     viewer->spinOnce(1); // ms

--- a/src/lib/plane_segment.cpp
+++ b/src/lib/plane_segment.cpp
@@ -73,9 +73,9 @@ PlaneSegment::PlaneSegment(Params params, ros::NodeHandle nh) :
                                                             &PlaneSegment::cloudCallback, this);
   
   // Detect table obstacle
-  pub_max_plane_ = nh_.advertise<sensor_msgs::PointCloud2>("/vision/max_plane", 1, true);
-  pub_cloud_ = nh_.advertise<sensor_msgs::PointCloud2>("/vision/points", 1, true);
-  pub_max_mesh_ = nh_.advertise<geometry_msgs::PolygonStamped>("/vision/max_mesh",1, true);
+  pub_max_plane_ = nh_.advertise<sensor_msgs::PointCloud2>("vision/max_plane", 1, true);
+  pub_cloud_ = nh_.advertise<sensor_msgs::PointCloud2>("vision/points", 1, true);
+  pub_max_mesh_ = nh_.advertise<geometry_msgs::PolygonStamped>("vision/max_mesh",1, true);
   
   // Visualizer
   if(viz){    

--- a/src/lib/plane_segment.h
+++ b/src/lib/plane_segment.h
@@ -92,6 +92,7 @@ struct Params {
   double area_max = 0.0;
   double xy_resolution = 0.05;
   double z_resolution = 0.02;
+  bool viz = true;
   std::string base_frame = "mobile_base_link";
   std::string cloud_topic = "/oil/perception/head_camera/cloud";
 };
@@ -222,7 +223,8 @@ private:
   Utilities *utl_;
   HighResTimer hst_;
   boost::shared_ptr<pcl::visualization::PCLVisualizer> viewer;
-
+  bool viz;
+  
   void computeNormalAndFilter();
   
   /// Core process for finding planes


### PR DESCRIPTION
A few small changes

- Add config param `viz` to enable/disable viewer 
- Advertise topics in relative namespace 
- Use ROS logs instead of std 
- Use unfiltered cloud as input to algorithm since filtered cloud does not have rgb data which causes pcl to throw warnings that cannot be suppressed using rosconsole